### PR TITLE
Turn off vars-on-top

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = {
 
     rules: {
         'eqeqeq': [ERR, 'smart'],
-        'no-undefined': 0
+        'no-undefined': 0,
+        'vars-on-top': 0,
     }
 };


### PR DESCRIPTION
Like we agreed on in the code-style meeting.

Reason: We don't see the value of the rule. Especially since `var` is dissallowed anyways.