### PR TITLE
Turn off no-undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,5 +8,6 @@ module.exports = {
 
     rules: {
         'eqeqeq': [ERR, 'smart'],
+        'no-undefined': 0
     }
 };


### PR DESCRIPTION
Like we agreed on in the code-style meeting.

Reason: We don't see the value of the rule. `undefined` and be redefined since ES5, so the original reason for the rule does not apply anymore.