### PR TITLE
Allow hoisting functions [no-use-before-define]

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = {
         'no-useless-call': ERR,
         'no-duplicate-imports': ERR,
         'no-shadow-restricted-names': ERR,
+        'no-use-before-define': [ERR, { functions: false }],
         'prefer-spread': ERR,
         'yoda': ERR,
         'array-callback-return': ERR,


### PR DESCRIPTION
Almost what we agreed on in the code-style meeting.

Reason: It's safe to rely on hoisting of function declarations, so it doesn't make sense to us to disallow it. We also talked about allowing hoisting of classes, but according to the eslint docs, it's not safe - so I vote for disallowing hoisting of classes. http://eslint.org/docs/rules/no-use-before-define