### PR TITLE
Turn off no-shadow

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,5 +8,6 @@ module.exports = {
 
     rules: {
         'eqeqeq': [ERR, 'smart'],
+        'no-shadow': 0
     }
 };


### PR DESCRIPTION
Like we agreed on in the code-style meeting.

Reason: We don't think the problem the rule tries to solve is relevant, and mostly it is only in the way when you're shadowing variables that doesn't matter like `err`, `callback`, etc...