### PR TITLE
Add check for missing rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "docs": "node bin/generate-rule-docs.js index.js > rules.md",
     "test": "eslint . && node test/config-test.js",
+    "eslint-find-rules": "eslint-find-rules -u",
     "preversion": "npm prune && npm test"
   },
   "keywords": [
@@ -33,6 +34,7 @@
   "devDependencies": {
     "async": "^1.5.2",
     "eslint": ">=2.0.0",
+    "eslint-find-rules": "^1.10.0",
     "marked": "^0.3.5"
   },
   "dependencies": {


### PR DESCRIPTION
Once we define every rules, this (as part of  `npm test`) combined with greenkeeper will alert us to every new rule, as it'll fail the build.

Current output:

![image](https://cloud.githubusercontent.com/assets/1404810/16116044/0466acca-33cb-11e6-954e-26089cd13e2b.png)