### PR TITLE
Allow use of double quotes to avoid escaping

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,5 +46,6 @@ module.exports = {
         'no-useless-escape': ERR,
         'quote-props': [ERR, 'consistent-as-needed'],
         'no-negated-condition': ERR,
+        'quotes': [ERR, 'single', { avoidEscape: true }],
     },
 };


### PR DESCRIPTION
Because `"I don't like needless escaping"` > `'I don\'t like needless escaping'`