### PR TITLE
Add `prefer-const`

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ module.exports = {
         'no-useless-call': ERR,
         'no-useless-escape': ERR,
         'one-var': [ERR, 'never'],
+        'prefer-const': ERR,
         'prefer-spread': ERR,
         'prefer-template': ERR,
         'quote-props': [ERR, 'consistent-as-needed'],


### PR DESCRIPTION
Disabled in spt, for some reason: https://github.com/schibsted/eslint-config-spt/blob/master/env-es6.js#L17

http://eslint.org/docs/rules/prefer-const