### PR TITLE
Remove globals from `no-shadow`

### DIFF
--- a/packages/eslint-config-finn/index.js
+++ b/packages/eslint-config-finn/index.js
@@ -32,7 +32,7 @@ module.exports = {
         'no-eq-null': 'off',
         'no-negated-condition': 'error',
         'no-negated-in-lhs': 'error',
-        'no-shadow': ['error', { builtinGlobals: true, allow: ['resolve', 'reject', 'cb', 'err'] }],
+        'no-shadow': ['error', { allow: ['resolve', 'reject', 'cb', 'err'] }],
         'no-shadow-restricted-names': 'error',
         'no-spaced-func': 'error',
         'no-trailing-spaces': 'error',

--- a/rules.md
+++ b/rules.md
@@ -256,7 +256,6 @@ disallow variable declarations from shadowing variables declared in the outer sc
 * `never` - never report shadowing before the outer variables/functions are defined.
 
 ### Current options
-  * builtinGlobals = true
   * allow = resolve,reject,cb,err
 
 ## [no-undef-init](http://eslint.org/docs/rules/no-undef-init)


### PR DESCRIPTION
It's annoying not being allowed to call something `name` or `event`. It outweighs the footgun it is to overwrite `Promise` or `fetch`, IMO.

/cc @sveisvei @peternic @CMTegner