### PR TITLE
Prettier: Use default printWidth (80)

### DIFF
--- a/packages/eslint-config-finn-prettier/prettier.js
+++ b/packages/eslint-config-finn-prettier/prettier.js
@@ -5,8 +5,7 @@ module.exports = {
     plugins: [
         'prettier',
     ],
-
     rules: {
-        'prettier/prettier': ['error', { printWidth: 120, tabWidth: 4, singleQuote: true, trailingComma: 'es5' }],
+        'prettier/prettier': ['error', { tabWidth: 4, singleQuote: true, trailingComma: 'es5' }],
     },
 };


### PR DESCRIPTION
While I usually like wider code, it means prettier will inline way more stuff than we would naturally. While not a perfect heuristic (expression width would be better: prettier/prettier#1099), it generally turns out prettier code.