### PR TITLE
fix: turn off no-did-mount-set-state

### DIFF
--- a/packages/eslint-config-finn-react/react.js
+++ b/packages/eslint-config-finn-react/react.js
@@ -4,5 +4,6 @@ module.exports = {
     extends: ['eslint-config-schibsted-react'],
     rules: {
         'react/no-multi-comp': ['error', { ignoreStateless: true }],
+        'react/no-did-mount-set-state': 'off',
     },
 };


### PR DESCRIPTION
Turn off no-did-mount-set-state to match airbnb https://github.com/airbnb/javascript/commit/44dbd0bdc41d08eb5de8ad698099ae44240f4b0d